### PR TITLE
IMPROVE make tools usable in windows

### DIFF
--- a/nextnprodid.py
+++ b/nextnprodid.py
@@ -47,7 +47,10 @@ base_path = os.path.dirname(__file__)
 configfile = os.path.abspath(os.path.join(base_path, "config.ini"))
 
 # get reserved ids from config file
-locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
+try:
+    locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
+except locale.Error:
+    locale.setlocale(locale.LC_ALL, 'german_Germany')
 cfg = ConfigParser({})
 cfg.readfp(codecs.open(configfile, 'r', 'utf8'))
 res = cfg.get('nextprodid', 'reserved_ids').replace(' ', '').replace('[[', '').replace(']]', '')

--- a/nextprodid.py
+++ b/nextprodid.py
@@ -44,7 +44,11 @@ base_path = os.path.dirname(__file__)
 configfile = os.path.abspath(os.path.join(base_path, "config.ini"))
 
 # get reserved ids from config file
-locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
+try:
+    locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
+except locale.Error:
+    locale.setlocale(locale.LC_ALL, 'german_Germany')
+    
 cfg = ConfigParser({})
 cfg.readfp(codecs.open(configfile, 'r', 'utf8'))
 res = cfg.get('nextprodid', 'reserved_ids').replace(' ', '').replace('[[', '').replace(']]', '')

--- a/oerphelper.py
+++ b/oerphelper.py
@@ -6,7 +6,10 @@ from ConfigParser import ConfigParser
 import codecs
 import os
 
-locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
+try:
+    locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
+except locale.Error:
+    locale.setlocale(locale.LC_ALL, 'german_Germany')
 
 basepath = os.path.dirname(__file__)
 configfile = os.path.abspath(os.path.join(basepath, "config.ini"))


### PR DESCRIPTION
running the tools on windows occures an error at
`locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")`
Windows doesn't support the location called `"de_DE.UTF-8"`, it wants to
get `'german_Germany'` so there is now an exception handle added to make
tools usable in linux and windows